### PR TITLE
chore: [Build] remove unused rollup configuration items

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -88,7 +88,6 @@ export default () => {
     case 'esm':
       return {
         input: [entryFile, ...componentEntryFiles],
-        preserveModules: true, // rollup-plugin-styles 还是需要使用
         output: { ...esOutput, dir: 'dist/es', format: 'es'},
         external,
         plugins: [postcss(postcssConfig), ...commonPlugins]
@@ -96,7 +95,6 @@ export default () => {
     case 'cjs':
       return {
         input: [entryFile, ...componentEntryFiles],
-        preserveModules: true, // rollup-plugin-styles 还是需要使用
         output: { ...esOutput, dir: 'dist/cjs', format: 'cjs'},
         external,
         plugins: [postcss(postcssConfig), ...commonPlugins]

--- a/packages/icons/rollup.config.js
+++ b/packages/icons/rollup.config.js
@@ -77,7 +77,6 @@ export default () => {
     case 'esm':
       return {
         input: [entryFile, ...componentEntryFiles],
-        preserveModules: true, // rollup-plugin-styles 还是需要使用
         output: { ...esOutput, dir: 'dist/es', format: 'es' },
         external,
         plugins: [postcss(postcssConfig), ...commonPlugins],
@@ -85,7 +84,6 @@ export default () => {
     case 'cjs':
       return {
         input: [entryFile, ...componentEntryFiles],
-        preserveModules: true, // rollup-plugin-styles 还是需要使用
         output: { ...esOutput, dir: 'dist/cjs', format: 'cjs' },
         external,
         plugins: [postcss(postcssConfig), ...commonPlugins],


### PR DESCRIPTION
affects: @acme-ui/core, @acme-ui/icons